### PR TITLE
improved configuration handling

### DIFF
--- a/neo.go
+++ b/neo.go
@@ -1,9 +1,6 @@
 package neo
 
-import (
-	"github.com/ivpusic/golog"
-	"os"
-)
+import "github.com/ivpusic/golog"
 
 // Type which will be passed as argument of ``panic`` if Neo assertion fails.
 type NeoAssertError struct {
@@ -24,25 +21,10 @@ func init() {
 }
 
 // Getting Neo Application instance. This is singleton function.
-// First time when we call this method function will try to parse configuration for Neo application.
-// It will look for configuration file provided by ``--config`` CLI argument (if exist).
 func App() *Application {
 	if app == nil {
-		confFile := ""
-
-		for i, arg := range os.Args {
-			if arg == "--config" {
-				if len(arg) > i+1 {
-					confFile = os.Args[i+1]
-					break
-				}
-			}
-		}
-
-		app = &Application{}
-		app.init(confFile)
+		return &Application{}
 	}
-
 	return app
 }
 


### PR DESCRIPTION
Me and my friend were hacking on neo, and we ran into an issue where setting a configuration file is really hard.

There are only 2 ways to do it in current version of neo.

1.) Injecting a fake argument into `os.Args`:
```
	neoConfigFlag := []string{"--config", util.RelativePath("config", "neo_config.toml")}
	os.Args = append(os.Args, neoConfigFlag...)
```
The problem with this approach is that if the app is a CLI application using a framework like `codegangsta/cli`, the injection has to be done at a later time or it will break `cli`. Also its pretty non-idiomatic.

2.) Manual Override:
```
	app := neo.App()
	defer app.Start()

	// config := &neo.Conf{}
	// config.Parse(util.RelativePath("config", "neo_config.toml"))
	// app.Conf = config
```
This has an issue that the logger will complain since the neo.App() will try to set "" config file.
Also, 3 lines of code is kinda ugly.

This PR allows the user to set their config like so:
```
	app := neo.App()
	app.SetConfigFile(util.RelativePath("config", "neo_config.toml")) // $REPO/config/neo_config.toml
	defer app.Start()
```
Its just 1 line of code. Also, if this isn't set, it will fall-back to `--config`.

If you agree with the idea, I will look into further improving the code and testing it out. I literally hacked this PR in 10min @ 4am so it might break something.

