### PR TITLE
ctx.Writer, ctx.Header is possible to overwrite

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -40,8 +40,8 @@ func getTestApp(t *testing.T) *httpcheck.Checker {
 	})
 
 	app.Get("/header", func(this *Ctx) {
-		this.Res.Header.Set("key", "value")
-		this.Res.Header.Set("key1", "value1")
+		this.Res.Header().Set("key", "value")
+		this.Res.Header().Set("key1", "value1")
 		this.Res.Status = 200
 	})
 


### PR DESCRIPTION
I'm thinking ctx.Res should implement ResponseWriter to hide Writer/Header.