### PR TITLE
Add Writer() for Response to get http.ResponseWriter and fix a bug of neo cli

### DIFF
--- a/cmd/neo/scripts/neo-html-template.go
+++ b/cmd/neo/scripts/neo-html-template.go
@@ -35,7 +35,7 @@ func main() {
 	app := neo.App()
 
 	app.Use(logger.Log)
-	app.Templates("*")
+	app.Templates("index.tpl")
 
 	app.Get("/", func(ctx *neo.Ctx) (int, error) {
 		return 200, ctx.Res.Tpl("index", struct {

--- a/response.go
+++ b/response.go
@@ -107,6 +107,11 @@ func (r *Response) WriteHeader(s int) {
 	r.writer.WriteHeader(s)
 }
 
+// Get http.ResponseWriter directly
+func (r *Response) Writer() http.ResponseWriter {
+	return r.writer
+}
+
 // Checking if file exist.
 // todo: consider moving this to utils.go
 func (r *Response) fileExists(file string) bool {


### PR DESCRIPTION
* Add Writer() for Response to get http.ResponseWriter directly, which is useful when serving file content with http.ServeContent.
(ServeContent is useful for distibuted file system, it doesn't need a file path)

* Fix Bug of neo cli see #23 