### PR TITLE
Change neo.middleware to neo.Middleware

### DIFF
--- a/interceptor.go
+++ b/interceptor.go
@@ -15,9 +15,9 @@ func compose(fns []appliable) func(*Ctx) {
 
 // Representing middleware handler.
 // It accepts Neo Context and Next function for calling next middleware in chain.
-type middleware func(*Ctx, Next)
+type Middleware func(*Ctx, Next)
 
-func (m middleware) apply(ctx *Ctx, fns []appliable, current int) {
+func (m Middleware) apply(ctx *Ctx, fns []appliable, current int) {
 	m(ctx, func() {
 		current++
 		if len(fns) > current {
@@ -32,6 +32,6 @@ type interceptor struct {
 }
 
 // Adding new middleware into chain of middlewares.
-func (m *interceptor) Use(fn middleware) {
+func (m *interceptor) Use(fn Middleware) {
 	m.middlewares = append(m.middlewares, appliable(&fn))
 }

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -85,7 +85,7 @@ func TestComposeWithDownstream(t *testing.T) {
 }
 
 func TestComposeWithoutDownstream(t *testing.T) {
-	var noDownstream middleware = testMiddlewareWithoutDownstream
+	var noDownstream Middleware = testMiddlewareWithoutDownstream
 
 	middlewares := []appliable{
 		noDownstream,

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -35,7 +35,7 @@ func testMiddlewareWithoutDownstream(ctx *Ctx, next Next) {
 }
 
 func TestCompose(t *testing.T) {
-	var mdw middleware = testMiddleware
+	var mdw Middleware = testMiddleware
 
 	middlewares := []appliable{
 		mdw,
@@ -59,8 +59,8 @@ func TestCompose(t *testing.T) {
 }
 
 func TestComposeWithDownstream(t *testing.T) {
-	var downstream middleware = testMiddlewareWithDownstream
-	var normalMdw middleware = testMiddleware
+	var downstream Middleware = testMiddlewareWithDownstream
+	var normalMdw Middleware = testMiddleware
 
 	middlewares := []appliable{
 		normalMdw,


### PR DESCRIPTION
Change neo.middleware to neo.Middleware, so can be used to create more powerful middleware.
For example, [jwt middleware](https://github.com/diankong/neomw/blob/master/jwt/jwt.go)
